### PR TITLE
Copyright date update

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Linux Mint Troubleshooting Guide'
-copyright = '2017, Linux Mint'
+copyright = '2017–2018, Linux Mint'
 author = 'Linux Mint'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Update of copyright date to reflect current year. A range ("2017–2018") has been used as I imagine that this document will be evolving over the years. I assume that the copyright variable is the origin of the copyright notice at the bottom of each Troubleshooting Guide page - if not, this will also have to be amended. Naturally, if the current year can be determined programmatically then the copyright date will not have to be similarly updated every year e.g. (datetime module required) copyright = '2017–' + str(datetime.datetime.now().year) + ', Linux Mint'.